### PR TITLE
Batch security refactors

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,34 @@
+name: Validate
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  hassfest:
+    name: hassfest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: home-assistant/actions/hassfest@master
+
+  ruff:
+    name: ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+
+  eslint:
+    name: eslint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __pycache__/
 .DS_Store
 .env
 *.log
+.venv/
+node_modules/
+.ruff_cache/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A custom component that fetches and downloads the latest recordings from your **
 ## Features
 
 - Automatically discovers and downloads the latest recordings stored in your Reolink Home Hub from connected battery-powered cameras
-- Makes recordings available via `/local/` URLs for reliable access
+- Makes recordings available via Home Assistant's authenticated media source (requires login)
 - Creates sensors with attributes containing recording details
 - Detects specific event types (Motion, Person, Vehicle, Animal) from recording metadata
 - Uses fixed filenames for latest recordings to simplify dashboard usage
@@ -43,7 +43,7 @@ A custom component that fetches and downloads the latest recordings from your **
 ### Configuration Options
 After setup, you can adjust these options:
 - Scan Interval: How often to check for new recordings (in minutes)
-- Storage Path: Where to store downloaded recordings (should be set to `www/reolink_recordings` for proper functionality)
+- Storage Path: Where to store downloaded recordings (default: `reolink_recordings`, under your HA config directory — do **not** use a path under `www/`, which is publicly accessible)
 - Snapshot Format: Choose between animated GIF, static JPG, or both for snapshots
 - Enable Caching: Toggle the caching system on/off (useful to disable during development/debugging)
 - Resolution Preference: Choose between high-resolution (default) or low-resolution streams when browsing recordings
@@ -67,7 +67,7 @@ show_state: true
 show_name: true
 tap_action:
   action: url
-  url_path: /local/reolink_recordings/recordings/camera_name_latest.mp4
+  url_path: /api/sensor/sensor.camera_name_latest_recording/attribute/media_url
 ```
 
 Replace:
@@ -194,15 +194,21 @@ Each sensor has these attributes:
 - `event_type`: The detected event type (e.g., "Motion", "Motion Person", "Vehicle", "Animal")
 - `file_path`: Full path to the recording file
 - `file_name`: Name of the recording file
-- `media_url`: URL to access the media with cache-busting parameter
-- `entity_picture`: URL to the snapshot image (GIF or JPG based on configuration)
-- `jpg_picture`: URL to the JPG snapshot (when using both GIF and JPG format)
+- `media_url`: Authenticated URL to access the MP4 recording (via `/media-source/reolink_recordings/...`)
+- `entity_picture`: Authenticated URL to the snapshot image (GIF or JPG based on configuration)
+- `jpg_picture`: Authenticated URL to the JPG snapshot (when using both GIF and JPG format)
 
 These attributes can be used in automations, templates, and dashboard cards.
 
 ## Viewing Recordings
 
-All recordings downloaded from your Reolink Home Hub are stored in the `www/reolink_recordings/recordings` directory and can be accessed via `/local/reolink_recordings/recordings/` URLs. Each connected camera has fixed filenames for the latest recording (`camera_name_latest.mp4`), animated preview (`camera_name_latest.gif`), and snapshot (`camera_name_latest.jpg`) for easy reference in dashboards.
+Recordings are stored under `<config>/reolink_recordings/recordings/` by default (outside the public `www/` directory). They are served through Home Assistant's authenticated media source at `/media-source/reolink_recordings/...`, so only logged-in users can access surveillance footage.
+
+Each connected camera has fixed filenames for the latest recording (`camera_name_latest.mp4`), animated preview (`camera_name_latest.gif`), and snapshot (`camera_name_latest.jpg`) for easy reference in dashboards and automations.
+
+### Upgrading from earlier versions
+
+If you previously used `www/reolink_recordings` as the storage path, update the integration option to `reolink_recordings` (or another path outside `www/`), move any existing files from `www/reolink_recordings/recordings/` to the new location, and restart Home Assistant. Existing installs are migrated automatically on upgrade, but files must be moved manually or re-downloaded via a refresh.
 
 ## Performance Optimizations
 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,13 @@ A custom component that fetches and downloads the latest recordings from your **
 4. Follow the configuration steps:
    - Name: A name for this integration
    - Host: Your Home Assistant URL (default: http://localhost:8123)
-   - Username: Your Home Assistant username (not used yet)
-   - Password: Your Home Assistant Long-Lived Access Token
+   - Access Token: Your Home Assistant Long-Lived Access Token
      - Create one at your profile page → Long-Lived Access Tokens
 
 ### Configuration Options
 After setup, you can adjust these options:
 - Scan Interval: How often to check for new recordings (in minutes)
-- Storage Path: Where to store downloaded recordings (default: `reolink_recordings`, under your HA config directory — do **not** use a path under `www/`, which is publicly accessible)
+- Storage Path: Where to store downloaded recordings (default: `reolink_recordings` under your HA config directory). Absolute paths are allowed (e.g. `/media/reolink_recordings` or a NAS mount). Avoid `www/`, which is publicly accessible without login — a warning is logged if you use it.
 - Snapshot Format: Choose between animated GIF, static JPG, or both for snapshots
 - Enable Caching: Toggle the caching system on/off (useful to disable during development/debugging)
 - Resolution Preference: Choose between high-resolution (default) or low-resolution streams when browsing recordings

--- a/README.md
+++ b/README.md
@@ -216,3 +216,39 @@ If you previously used `www/reolink_recordings` as the storage path, update the 
 The integration includes an intelligent caching system that avoids redundant downloads of identical recordings. Each recording is assigned a unique ID based on camera index, timestamp, event type, and duration. When a recording with the same ID is detected, the download is skipped, reducing network traffic and CPU usage.
 
 You can disable caching in the integration options when debugging or developing new features.
+
+## Development
+
+Pull requests and pushes run GitHub Actions (`.github/workflows/validate.yml`) with three jobs:
+
+- **hassfest** — validates `manifest.json`, translations, config flow, and `services.yaml`
+- **ruff** — Python linting
+- **eslint** — Lovelace card linting in `frontend/`
+
+The workflow also runs nightly to catch upstream Home Assistant rule changes.
+
+### Run checks locally
+
+**Python (Ruff):**
+
+```bash
+pip install ruff
+ruff check .
+```
+
+**JavaScript (ESLint):**
+
+```bash
+npm install
+npm run lint
+```
+
+**Home Assistant validation (hassfest):**
+
+Hassfest runs in CI via Docker. To run it locally:
+
+```bash
+docker run --rm -v "${PWD}://github/workspace" ghcr.io/home-assistant/hassfest
+```
+
+On Windows PowerShell, use `$PWD.Path` instead of `$PWD` in the volume mount if needed.

--- a/TODO.md
+++ b/TODO.md
@@ -34,19 +34,19 @@ Items identified during a security review of this repository.
 
 ## Low Priority
 
-- [ ] **Improve token storage pattern**
+- [x] **Improve token storage pattern**
   - Long-lived access token is stored in `CONF_PASSWORD`; `CONF_USERNAME` is unused.
   - **Fix:** Consider a dedicated config key (e.g. `access_token`) with a config entry migration for existing installs.
 
-- [ ] **Restrict the refresh service to admin users** (`__init__.py`)
+- [x] **Restrict the refresh service to admin users** (`__init__.py`)
   - `reolink_recordings.refresh` triggers full re-downloads using the stored token with no explicit permission check.
   - **Fix:** Register as an admin-only service or verify caller permissions in the handler.
 
-- [ ] **Validate `storage_path` option** (`config_flow.py`, `__init__.py`)
+- [x] **Validate `storage_path` option** (`config_flow.py`, `__init__.py`)
   - Admins can set `storage_path` to any path under the HA config tree with no validation.
-  - **Fix:** Constrain paths to an expected directory (e.g. under config root, reject `www/` for recordings).
+  - **Fix:** Allow absolute paths; keep relative paths under config (reject `..`); warn if under `www/`.
 
-- [ ] **Use unique temp files for ffmpeg GIF generation** (`coordinator.py`)
+- [x] **Use unique temp files for ffmpeg GIF generation** (`coordinator.py`)
   - GIF generation writes to a shared `/tmp/palette.png`, which can collide when multiple instances run concurrently.
   - **Fix:** Use `tempfile` or a UUID-based temp path per invocation.
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ Items identified during a security review of this repository.
 
 ## High Priority
 
-- [ ] **Stop serving recordings via public `/local/` URLs**
+- [x] **Stop serving recordings via public `/local/` URLs**
   - Recordings are stored under `www/reolink_recordings` and exposed as `/local/reolink_recordings/recordings/...` in `sensor.py`.
   - Home Assistant serves `/local/` without authentication — anyone who can reach the instance may access surveillance footage.
   - **Fix:** Move storage outside `www/` (e.g. under the HA config directory), update default `storage_path`, and serve media through the authenticated media source (`/media-source/reolink_recordings/...`) instead of `/local/`.
@@ -119,7 +119,6 @@ Create `.github/workflows/validate.yml` with jobs for hassfest, HACS, and Ruff (
 
 These require code changes from the security section above, not automation alone:
 
-- Public `/local/` recording exposure
 - Token redaction in debug logs
 - `ssl=None` WebSocket behavior
 - XSS in custom cards (ESLint can help only after rules are added)

--- a/TODO.md
+++ b/TODO.md
@@ -28,7 +28,7 @@ Items identified during a security review of this repository.
   - `file_path` exposes the full local path in `extra_state_attributes`.
   - **Fix:** Remove `file_path` from attributes or expose only the filename / media-source identifier.
 
-- [ ] **Fix `ssl=None` on WebSocket connections** (`coordinator.py`, line ~808)
+- [x] **Fix `ssl=None` on WebSocket connections** (`coordinator.py`, line ~808)
   - `websockets.connect(websocket_url, ssl=None)` may disable or bypass proper TLS verification for `wss://` connections.
   - **Fix:** Use the default SSL context for `wss://` (or an explicit verified context); only omit SSL for plain `ws://` localhost connections if needed.
 
@@ -120,5 +120,4 @@ Create `.github/workflows/validate.yml` with jobs for hassfest, HACS, and Ruff (
 These require code changes from the security section above, not automation alone:
 
 - Token redaction in debug logs
-- `ssl=None` WebSocket behavior
 - XSS in custom cards (ESLint can help only after rules are added)

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,125 @@
+# Security & Hardening TODO
+
+Items identified during a security review of this repository.
+
+## High Priority
+
+- [ ] **Stop serving recordings via public `/local/` URLs**
+  - Recordings are stored under `www/reolink_recordings` and exposed as `/local/reolink_recordings/recordings/...` in `sensor.py`.
+  - Home Assistant serves `/local/` without authentication — anyone who can reach the instance may access surveillance footage.
+  - **Fix:** Move storage outside `www/` (e.g. under the HA config directory), update default `storage_path`, and serve media through the authenticated media source (`/media-source/reolink_recordings/...`) instead of `/local/`.
+
+## Medium Priority
+
+- [ ] **Redact tokens from debug logs** (`coordinator.py`)
+  - WebSocket auth requests log the full `access_token` at debug level (line ~866).
+  - Download requests log `Authorization` headers at debug level (line ~940).
+  - **Fix:** Redact or omit sensitive fields before logging.
+
+- [ ] **Validate credentials during config flow** (`config_flow.py`)
+  - Setup accepts any host/username/password without verifying the long-lived access token works.
+  - **Fix:** Test the token against HA's WebSocket or REST API during `async_step_user` before creating the config entry.
+
+- [ ] **Fix XSS risk in custom Lovelace cards**
+  - `frontend/reolink-recording-card.js` and `frontend/reolink-summary-card.js` inject entity data (camera names, event types, timestamps) into `innerHTML` without escaping.
+  - **Fix:** Use `textContent`, DOM APIs, or an HTML-escape helper for all dynamic values.
+
+- [ ] **Remove filesystem path from public entity attributes** (`sensor.py`)
+  - `file_path` exposes the full local path in `extra_state_attributes`.
+  - **Fix:** Remove `file_path` from attributes or expose only the filename / media-source identifier.
+
+- [ ] **Fix `ssl=None` on WebSocket connections** (`coordinator.py`, line ~808)
+  - `websockets.connect(websocket_url, ssl=None)` may disable or bypass proper TLS verification for `wss://` connections.
+  - **Fix:** Use the default SSL context for `wss://` (or an explicit verified context); only omit SSL for plain `ws://` localhost connections if needed.
+
+## Low Priority
+
+- [ ] **Improve token storage pattern**
+  - Long-lived access token is stored in `CONF_PASSWORD`; `CONF_USERNAME` is unused.
+  - **Fix:** Consider a dedicated config key (e.g. `access_token`) with a config entry migration for existing installs.
+
+- [ ] **Restrict the refresh service to admin users** (`__init__.py`)
+  - `reolink_recordings.refresh` triggers full re-downloads using the stored token with no explicit permission check.
+  - **Fix:** Register as an admin-only service or verify caller permissions in the handler.
+
+- [ ] **Validate `storage_path` option** (`config_flow.py`, `__init__.py`)
+  - Admins can set `storage_path` to any path under the HA config tree with no validation.
+  - **Fix:** Constrain paths to an expected directory (e.g. under config root, reject `www/` for recordings).
+
+- [ ] **Use unique temp files for ffmpeg GIF generation** (`coordinator.py`)
+  - GIF generation writes to a shared `/tmp/palette.png`, which can collide when multiple instances run concurrently.
+  - **Fix:** Use `tempfile` or a UUID-based temp path per invocation.
+
+## Documentation & API Consistency
+
+Services, triggers, and README are out of sync with the code.
+
+- [ ] **Reconcile manual refresh / redownload services**
+  - **Implemented:** `reolink_recordings.refresh` in `__init__.py` (optional `entry_id`), calls `coordinator.async_refresh()`.
+  - **Documented in README:** `reolink_recordings.fetch_latest_recordings` and `reolink_recordings.download_recording` — neither is registered in code.
+  - **Declared in `services.yaml`:** `fetch_latest_recordings` and `download_recording` — also not registered.
+  - **Constants in `const.py`:** `SERVICE_FETCH_LATEST` and `SERVICE_DOWNLOAD_RECORDING` — unused.
+  - **Fix:** Pick one approach and align everything:
+    - Option A: Implement the documented services (`fetch_latest_recordings` → full refresh; `download_recording` → single-camera download via existing `_discover_and_download_camera`), and keep or alias `refresh`.
+    - Option B: Remove the unused constants and update `services.yaml` + README to document only `reolink_recordings.refresh`.
+
+- [ ] **Document device triggers and redownload automations** (`README.md`)
+  - `device_trigger.py` exposes per-camera triggers: `recording_updated`, `vehicle_detected`, `person_detected`, `motion_detected` (translations in `translations/en.json`).
+  - README mentions using sensor attributes in automations but does not document device triggers or example automations for reacting to new recordings / triggering a redownload.
+  - **Fix:** Add a section covering available device triggers, the `reolink_recordings_updated` event, and example automation YAML (e.g. call the refresh service when a recording updates).
+
+- [ ] **Document event-driven discovery options** (`README.md`)
+  - Config flow supports `enable_event_driven`, `upload_delay`, and motion-sensor-to-camera mapping (`config_flow.py`, `coordinator.py`).
+  - README configuration options omit these entirely.
+  - **Fix:** Document how motion-sensor-triggered discovery works and how it relates to periodic scan interval and manual refresh.
+
+- [ ] **Keep CI/service docs in sync after service reconciliation**
+  - Once services are aligned, update `services.yaml`, README, and any automation examples together so hassfest and user docs match registered handlers.
+
+## CI
+
+No CI is configured today (no `.github/workflows`, tests, or lint config). Recommended additions, in priority order:
+
+### Essential
+
+- [ ] **Add hassfest validation**
+  - Validates `manifest.json`, translations, config flow, and `services.yaml` against Home Assistant core requirements.
+  - Use `home-assistant/actions/hassfest@master` in a GitHub Actions workflow.
+  - May already flag mismatches: see **Documentation & API Consistency** — `services.yaml` and README do not match the registered `refresh` service.
+
+- [ ] **Add HACS validation**
+  - Required before HACS default-store submission (README notes HACS is not yet available).
+  - Use `hacs/action@main` with `category: integration`.
+
+### Recommended
+
+- [ ] **Add Ruff for Python linting**
+  - Low-effort static analysis across `coordinator.py`, `config_flow.py`, `sensor.py`, etc.
+  - No test suite required.
+
+- [ ] **Add Bandit (or similar) for security static analysis**
+  - Complements the security items above (subprocess usage, logging patterns, etc.).
+  - Does not replace manual review.
+
+### Later
+
+- [ ] **Add pytest with Home Assistant test helpers**
+  - No tests exist yet; meaningful coverage would need HA's test harness.
+  - Good targets: coordinator merge/slug logic, path handling, config validation.
+
+- [ ] **Add ESLint for Lovelace cards** (optional)
+  - `frontend/reolink-recording-card.js` and `frontend/reolink-summary-card.js` are plain JS with no build step.
+  - Lower priority than hassfest and Ruff.
+
+### Suggested workflow layout
+
+Create `.github/workflows/validate.yml` with jobs for hassfest, HACS, and Ruff (Bandit optional). Trigger on push, pull_request, and a daily schedule to catch upstream HA/hassfest changes.
+
+### What CI will not catch
+
+These require code changes from the security section above, not automation alone:
+
+- Public `/local/` recording exposure
+- Token redaction in debug logs
+- `ssl=None` WebSocket behavior
+- XSS in custom cards (ESLint can help only after rules are added)

--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,8 @@
 from datetime import timedelta
 import logging
 import os
-from pathlib import Path
+
+import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -11,11 +12,15 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryError
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.service import async_register_admin_service
 
 from .const import (
+    CONF_ACCESS_TOKEN,
     CONF_STORAGE_PATH,
     DATA_COORDINATOR,
     DEFAULT_SCAN_INTERVAL,
@@ -24,11 +29,59 @@ from .const import (
 )
 from .coordinator import ReolinkRecordingsCoordinator
 from .frontend import setup_frontend
+from .helpers import (
+    is_www_storage_path,
+    resolve_storage_path,
+    validate_storage_path,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 # Media source is not a regular platform, it's registered separately
 PLATFORMS = ["sensor"]
+
+SERVICE_REFRESH_SCHEMA = vol.Schema(
+    {
+        vol.Optional("entry_id"): cv.string,
+    }
+)
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old config entries to the current version."""
+    _LOGGER.debug(
+        "Migrating %s from version %s", config_entry.title, config_entry.version
+    )
+
+    data = dict(config_entry.data)
+    options = dict(config_entry.options)
+    version = config_entry.version
+
+    if version < 2:
+        storage_path = options.get(CONF_STORAGE_PATH, DEFAULT_STORAGE_PATH)
+        if storage_path == "www/reolink_recordings":
+            options[CONF_STORAGE_PATH] = DEFAULT_STORAGE_PATH
+            _LOGGER.info(
+                "Migrating storage path from www/reolink_recordings to %s. "
+                "Move existing recordings to the new directory or trigger a refresh "
+                "to re-download them.",
+                DEFAULT_STORAGE_PATH,
+            )
+        version = 2
+
+    if version < 3:
+        # Move long-lived token out of CONF_PASSWORD; drop unused CONF_USERNAME.
+        if CONF_ACCESS_TOKEN not in data and CONF_PASSWORD in data:
+            data[CONF_ACCESS_TOKEN] = data[CONF_PASSWORD]
+        data.pop(CONF_PASSWORD, None)
+        data.pop(CONF_USERNAME, None)
+        version = 3
+
+    hass.config_entries.async_update_entry(
+        config_entry, data=data, options=options, version=version
+    )
+    _LOGGER.info("Migration of %s to version %s successful", config_entry.title, version)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -37,23 +90,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Get configuration
     host = entry.data.get(CONF_HOST)
-    username = entry.data.get(CONF_USERNAME)
-    password = entry.data.get(CONF_PASSWORD)
+    access_token = entry.data.get(CONF_ACCESS_TOKEN) or entry.data.get(CONF_PASSWORD)
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
     storage_path = entry.options.get(CONF_STORAGE_PATH, DEFAULT_STORAGE_PATH)
 
-    if storage_path.startswith("www/"):
+    if error := validate_storage_path(hass, storage_path):
+        raise ConfigEntryError(
+            f"Invalid storage path '{storage_path}' ({error}). "
+            f"Use a relative path under the HA config directory "
+            f"(default: {DEFAULT_STORAGE_PATH}), or an absolute path "
+            f"such as a /media or NAS mount."
+        )
+
+    if is_www_storage_path(hass, storage_path):
         _LOGGER.warning(
             "Recordings are stored under %s, which is publicly served at /local/. "
-            "Update the storage path in integration options to %s (or another path "
-            "outside www/) and move your recordings to avoid exposing surveillance "
-            "footage without authentication.",
+            "Prefer %s (or another path outside www/) and move your recordings to "
+            "avoid exposing surveillance footage without authentication.",
             storage_path,
             DEFAULT_STORAGE_PATH,
         )
 
     # Create storage directory if it doesn't exist
-    storage_dir = Path(hass.config.path(storage_path))
+    storage_dir = resolve_storage_path(hass, storage_path)
     os.makedirs(storage_dir, exist_ok=True)
 
     # Create data coordinator
@@ -61,8 +120,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass,
         entry.entry_id,
         host,
-        username,
-        password,
+        access_token,
         storage_dir,
         entry=entry,  # Pass the entire config entry for access to options
     )
@@ -93,15 +151,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         model="Recordings Integration",
         sw_version="1.0",
     )
-    
+
     # Set up all platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # Register frontend resources
     setup_frontend(hass)
-    
-    # Register services
-    await register_services(hass, entry)
+
+    # Register services (once)
+    await register_services(hass)
 
     return True
 
@@ -115,33 +173,45 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.cleanup()
         hass.data[DOMAIN].pop(entry.entry_id)
 
+        # Remove admin service when last entry is unloaded
+        if not hass.data[DOMAIN] and hass.services.has_service(DOMAIN, "refresh"):
+            hass.services.async_remove(DOMAIN, "refresh")
+
     return unload_ok
 
 
-async def register_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Register services for Reolink Recordings."""
-    
-    async def handle_refresh(call):
-        """Handle the manual refresh service call."""
-        entry_id = call.data.get('entry_id', entry.entry_id)
-        if entry_id in hass.data[DOMAIN]:
-            coordinator = hass.data[DOMAIN][entry_id][DATA_COORDINATOR]
-            _LOGGER.info("Manual refresh requested for Reolink Recordings")
-            await coordinator.async_refresh()
-            _LOGGER.info("Manual refresh completed for Reolink Recordings")
-        else:
-            _LOGGER.error(f"Entry ID {entry_id} not found for refresh service call")
-    
-    import voluptuous as vol
+async def register_services(hass: HomeAssistant) -> None:
+    """Register admin-only services for Reolink Recordings."""
+    if hass.services.has_service(DOMAIN, "refresh"):
+        return
 
-    from homeassistant.helpers import config_validation as cv
-    
-    SERVICE_REFRESH_SCHEMA = vol.Schema({
-        vol.Optional('entry_id'): cv.string,
-    })
-    
-    hass.services.async_register(
-        DOMAIN, 'refresh', handle_refresh, schema=SERVICE_REFRESH_SCHEMA
+    async def handle_refresh(call: ServiceCall) -> None:
+        """Handle the manual refresh service call."""
+        entry_id = call.data.get("entry_id")
+        if entry_id:
+            targets = [entry_id] if entry_id in hass.data[DOMAIN] else []
+        else:
+            targets = list(hass.data[DOMAIN])
+
+        if not targets:
+            _LOGGER.error(
+                "No matching config entry for refresh service call (entry_id=%s)",
+                entry_id,
+            )
+            return
+
+        for target_id in targets:
+            coordinator = hass.data[DOMAIN][target_id][DATA_COORDINATOR]
+            _LOGGER.info("Manual refresh requested for Reolink Recordings (%s)", target_id)
+            await coordinator.async_refresh()
+            _LOGGER.info("Manual refresh completed for Reolink Recordings (%s)", target_id)
+
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        "refresh",
+        handle_refresh,
+        schema=SERVICE_REFRESH_SCHEMA,
     )
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -43,6 +43,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
     storage_path = entry.options.get(CONF_STORAGE_PATH, DEFAULT_STORAGE_PATH)
 
+    if storage_path.startswith("www/"):
+        _LOGGER.warning(
+            "Recordings are stored under %s, which is publicly served at /local/. "
+            "Update the storage path in integration options to %s (or another path "
+            "outside www/) and move your recordings to avoid exposing surveillance "
+            "footage without authentication.",
+            storage_path,
+            DEFAULT_STORAGE_PATH,
+        )
+
     # Create storage directory if it doesn't exist
     storage_dir = Path(hass.config.path(storage_path))
     os.makedirs(storage_dir, exist_ok=True)

--- a/__init__.py
+++ b/__init__.py
@@ -1,27 +1,26 @@
 """Custom component for managing Reolink camera recordings."""
-import os
-import logging
-import asyncio
 from datetime import timedelta
+import logging
+import os
 from pathlib import Path
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers import device_registry as dr
 from homeassistant.const import (
     CONF_HOST,
-    CONF_USERNAME,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
 )
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
-    DOMAIN,
-    DEFAULT_SCAN_INTERVAL,
     CONF_STORAGE_PATH,
-    DEFAULT_STORAGE_PATH,
     DATA_COORDINATOR,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_STORAGE_PATH,
+    DOMAIN,
 )
 from .coordinator import ReolinkRecordingsCoordinator
 from .frontend import setup_frontend
@@ -134,6 +133,7 @@ async def register_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
             _LOGGER.error(f"Entry ID {entry_id} not found for refresh service call")
     
     import voluptuous as vol
+
     from homeassistant.helpers import config_validation as cv
     
     SERVICE_REFRESH_SCHEMA = vol.Schema({

--- a/config_flow.py
+++ b/config_flow.py
@@ -8,14 +8,13 @@ from homeassistant import config_entries
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
-    CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
-    CONF_USERNAME,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import (
+    CONF_ACCESS_TOKEN,
     CONF_ENABLE_CACHING,
     CONF_ENABLE_EVENT_DRIVEN,
     CONF_MOTION_SENSOR_MAPPING,
@@ -37,6 +36,7 @@ from .const import (
     SNAPSHOT_FORMAT_GIF,
     SNAPSHOT_FORMAT_JPG,
 )
+from .helpers import is_www_storage_path, validate_storage_path
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,29 +44,7 @@ _LOGGER = logging.getLogger(__name__)
 class ReolinkRecordingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Reolink Recordings."""
 
-    VERSION = 2
-
-    @staticmethod
-    @callback
-    def async_migrate_entry(
-        hass: HomeAssistant, config_entry: config_entries.ConfigEntry
-    ) -> bool:
-        """Migrate old config entries."""
-        if config_entry.version == 1:
-            options = dict(config_entry.options)
-            storage_path = options.get(CONF_STORAGE_PATH, DEFAULT_STORAGE_PATH)
-            if storage_path == "www/reolink_recordings":
-                options[CONF_STORAGE_PATH] = DEFAULT_STORAGE_PATH
-                _LOGGER.info(
-                    "Migrating storage path from www/reolink_recordings to %s. "
-                    "Move existing recordings to the new directory or trigger a refresh "
-                    "to re-download them.",
-                    DEFAULT_STORAGE_PATH,
-                )
-            hass.config_entries.async_update_entry(
-                config_entry, options=options, version=2
-            )
-        return True
+    VERSION = 3
 
     @staticmethod
     @callback
@@ -107,8 +85,7 @@ class ReolinkRecordingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(CONF_NAME, default="Reolink Recordings"): str,
                     vol.Required(CONF_HOST, default="http://localhost:8123"): str,
-                    vol.Required(CONF_USERNAME): str,
-                    vol.Required(CONF_PASSWORD): str,
+                    vol.Required(CONF_ACCESS_TOKEN): str,
                 }
             ),
             errors=errors,
@@ -130,18 +107,30 @@ class ReolinkRecordingsOptionsFlow(config_entries.OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle options flow."""
+        errors: dict[str, str] = {}
+
         if user_input is not None:
-            # Check if user wants to configure motion sensor mapping
-            if user_input.get(CONF_ENABLE_EVENT_DRIVEN, False):
-                # Store the basic options and proceed to motion sensor mapping
-                self._basic_options = user_input
-                return await self.async_step_motion_sensors()
+            storage_path = user_input.get(CONF_STORAGE_PATH, DEFAULT_STORAGE_PATH)
+            if path_error := validate_storage_path(self.hass, storage_path):
+                errors[CONF_STORAGE_PATH] = path_error
             else:
+                if is_www_storage_path(self.hass, storage_path):
+                    _LOGGER.warning(
+                        "Storage path %s is under www/ and will be publicly served "
+                        "at /local/ without authentication. Prefer %s or another "
+                        "path outside www/.",
+                        storage_path,
+                        DEFAULT_STORAGE_PATH,
+                    )
+                if user_input.get(CONF_ENABLE_EVENT_DRIVEN, False):
+                    # Store the basic options and proceed to motion sensor mapping
+                    self._basic_options = user_input
+                    return await self.async_step_motion_sensors()
                 # Event-driven disabled, save options without mapping
                 return self.async_create_entry(title="", data=user_input)
 
         current_options = self._config_entry.options
-        
+
         options = {
             vol.Optional(
                 CONF_SCAN_INTERVAL,
@@ -196,8 +185,9 @@ class ReolinkRecordingsOptionsFlow(config_entries.OptionsFlow):
         }
 
         return self.async_show_form(
-            step_id="init", 
+            step_id="init",
             data_schema=vol.Schema(options),
+            errors=errors,
             description_placeholders={
                 "motion_sensor_info": "If event-driven discovery is enabled, you'll be able to configure motion sensor mappings on the next step."
             }
@@ -210,32 +200,32 @@ class ReolinkRecordingsOptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             # Combine basic options with motion sensor mapping
             final_options = {**self._basic_options}
-            
+
             # Build motion sensor mapping from user input
             motion_mapping = {}
             for key, value in user_input.items():
                 if key.startswith("sensor_") and value != "none":
                     sensor_id = key.replace("sensor_", "")
                     motion_mapping[sensor_id] = value
-            
+
             if motion_mapping:
                 final_options[CONF_MOTION_SENSOR_MAPPING] = motion_mapping
-            
+
             return self.async_create_entry(title="", data=final_options)
-        
+
         # Get available motion sensors and cameras
         await self._get_available_entities()
-        
+
         if not self._motion_sensors:
             # No motion sensors found, skip mapping
             return self.async_create_entry(title="", data=self._basic_options)
-        
+
         # Build schema for motion sensor mapping
         current_mapping = self._config_entry.options.get(CONF_MOTION_SENSOR_MAPPING, {})
         schema_dict = {}
-        
+
         camera_options = ["none"] + [f"{idx}: {name}" for idx, name in self._cameras]
-        
+
         for sensor in self._motion_sensors:
             # Find current mapping for this sensor
             current_camera = "none"
@@ -247,9 +237,9 @@ class ReolinkRecordingsOptionsFlow(config_entries.OptionsFlow):
                             current_camera = f"{idx}: {name}"
                             break
                     break
-            
+
             schema_dict[vol.Optional(f"sensor_{sensor}", default=current_camera)] = vol.In(camera_options)
-        
+
         return self.async_show_form(
             step_id="motion_sensors",
             data_schema=vol.Schema(schema_dict),
@@ -257,18 +247,18 @@ class ReolinkRecordingsOptionsFlow(config_entries.OptionsFlow):
                 "info": "Map motion sensors to cameras for event-driven recording updates. Select 'none' to disable mapping for a sensor."
             }
         )
-    
+
     async def _get_available_entities(self):
         """Get available motion sensors and cameras."""
         # Get motion sensors
         states = self.hass.states.async_all()
         self._motion_sensors = []
-        
+
         for state in states:
-            if (state.entity_id.startswith("binary_sensor.") and 
+            if (state.entity_id.startswith("binary_sensor.") and
                 (state.attributes.get("device_class") == "motion" or "motion" in state.entity_id.lower())):
                 self._motion_sensors.append(state.entity_id)
-        
+
         # Get cameras from coordinator if available
         self._cameras = []
         coordinator_data = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id, {}).get("coordinator")

--- a/config_flow.py
+++ b/config_flow.py
@@ -1,41 +1,41 @@
 """Config flow for Reolink Recordings integration."""
-import voluptuous as vol
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
+
+import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.core import HomeAssistant, callback
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
-    CONF_USERNAME,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
 )
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
-import homeassistant.helpers.config_validation as cv
 
 from .const import (
-    DOMAIN,
-    DEFAULT_SCAN_INTERVAL,
-    CONF_STORAGE_PATH,
-    DEFAULT_STORAGE_PATH,
-    CONF_SNAPSHOT_FORMAT,
-    DEFAULT_SNAPSHOT_FORMAT,
-    SNAPSHOT_FORMAT_GIF,
-    SNAPSHOT_FORMAT_JPG,
-    SNAPSHOT_FORMAT_BOTH,
     CONF_ENABLE_CACHING,
-    DEFAULT_ENABLE_CACHING,
+    CONF_ENABLE_EVENT_DRIVEN,
+    CONF_MOTION_SENSOR_MAPPING,
     CONF_RESOLUTION_PREFERENCE,
+    CONF_SNAPSHOT_FORMAT,
+    CONF_STORAGE_PATH,
+    CONF_UPLOAD_DELAY,
+    DEFAULT_ENABLE_CACHING,
+    DEFAULT_ENABLE_EVENT_DRIVEN,
     DEFAULT_RESOLUTION_PREFERENCE,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SNAPSHOT_FORMAT,
+    DEFAULT_STORAGE_PATH,
+    DEFAULT_UPLOAD_DELAY,
+    DOMAIN,
     RESOLUTION_HIGH,
     RESOLUTION_LOW,
-    CONF_UPLOAD_DELAY,
-    DEFAULT_UPLOAD_DELAY,
-    CONF_ENABLE_EVENT_DRIVEN,
-    DEFAULT_ENABLE_EVENT_DRIVEN,
-    CONF_MOTION_SENSOR_MAPPING,
+    SNAPSHOT_FORMAT_BOTH,
+    SNAPSHOT_FORMAT_GIF,
+    SNAPSHOT_FORMAT_JPG,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -77,10 +77,10 @@ class ReolinkRecordingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return ReolinkRecordingsOptionsFlow(config_entry)
 
     async def async_step_user(
-        self, user_input: Optional[Dict[str, Any]] = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step."""
-        errors: Dict[str, str] = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
             # Validate the provided data
@@ -127,7 +127,7 @@ class ReolinkRecordingsOptionsFlow(config_entries.OptionsFlow):
         super().__init__()
 
     async def async_step_init(
-        self, user_input: Optional[Dict[str, Any]] = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle options flow."""
         if user_input is not None:
@@ -204,7 +204,7 @@ class ReolinkRecordingsOptionsFlow(config_entries.OptionsFlow):
         )
 
     async def async_step_motion_sensors(
-        self, user_input: Optional[Dict[str, Any]] = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle motion sensor mapping configuration."""
         if user_input is not None:

--- a/config_flow.py
+++ b/config_flow.py
@@ -44,7 +44,29 @@ _LOGGER = logging.getLogger(__name__)
 class ReolinkRecordingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Reolink Recordings."""
 
-    VERSION = 1
+    VERSION = 2
+
+    @staticmethod
+    @callback
+    def async_migrate_entry(
+        hass: HomeAssistant, config_entry: config_entries.ConfigEntry
+    ) -> bool:
+        """Migrate old config entries."""
+        if config_entry.version == 1:
+            options = dict(config_entry.options)
+            storage_path = options.get(CONF_STORAGE_PATH, DEFAULT_STORAGE_PATH)
+            if storage_path == "www/reolink_recordings":
+                options[CONF_STORAGE_PATH] = DEFAULT_STORAGE_PATH
+                _LOGGER.info(
+                    "Migrating storage path from www/reolink_recordings to %s. "
+                    "Move existing recordings to the new directory or trigger a refresh "
+                    "to re-download them.",
+                    DEFAULT_STORAGE_PATH,
+                )
+            hass.config_entries.async_update_entry(
+                config_entry, options=options, version=2
+            )
+        return True
 
     @staticmethod
     @callback

--- a/const.py
+++ b/const.py
@@ -4,7 +4,7 @@ DOMAIN = "reolink_recordings"
 
 # Configuration
 DEFAULT_SCAN_INTERVAL = 15  # minutes
-DEFAULT_STORAGE_PATH = "www/reolink_recordings"
+DEFAULT_STORAGE_PATH = "reolink_recordings"
 CONF_STORAGE_PATH = "storage_path"
 CONF_ENABLE_CACHING = "enable_caching"
 DEFAULT_ENABLE_CACHING = True

--- a/const.py
+++ b/const.py
@@ -5,6 +5,7 @@ DOMAIN = "reolink_recordings"
 # Configuration
 DEFAULT_SCAN_INTERVAL = 15  # minutes
 DEFAULT_STORAGE_PATH = "reolink_recordings"
+CONF_ACCESS_TOKEN = "access_token"
 CONF_STORAGE_PATH = "storage_path"
 CONF_ENABLE_CACHING = "enable_caching"
 DEFAULT_ENABLE_CACHING = True

--- a/coordinator.py
+++ b/coordinator.py
@@ -1,40 +1,36 @@
 """Data coordinator for Reolink Recordings."""
-import os
-import logging
-import json
 import asyncio
-import aiohttp
-import websockets
-import time
 from datetime import datetime
+import json
+import logging
+import os
 from pathlib import Path
-from typing import Dict, List, Any, Optional, Union
+import time
+from typing import Any
 
-from homeassistant.core import HomeAssistant
+import websockets
+
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import dt as dt_util
 
 from .const import (
-    DOMAIN,
-    CONF_STORAGE_PATH,
-    DEFAULT_STORAGE_PATH,
+    CONF_ENABLE_CACHING,
+    CONF_ENABLE_EVENT_DRIVEN,
+    CONF_RESOLUTION_PREFERENCE,
     CONF_SNAPSHOT_FORMAT,
+    CONF_UPLOAD_DELAY,
+    DEFAULT_ENABLE_CACHING,
+    DEFAULT_ENABLE_EVENT_DRIVEN,
+    DEFAULT_RESOLUTION_PREFERENCE,
+    DEFAULT_SNAPSHOT_FORMAT,
+    DEFAULT_UPLOAD_DELAY,
+    EVENT_RECORDING_UPDATED,
+    RESOLUTION_HIGH,
+    SNAPSHOT_FORMAT_BOTH,
     SNAPSHOT_FORMAT_GIF,
     SNAPSHOT_FORMAT_JPG,
-    SNAPSHOT_FORMAT_BOTH,
-    DEFAULT_SNAPSHOT_FORMAT,
-    CONF_ENABLE_CACHING,
-    DEFAULT_ENABLE_CACHING,
-    CONF_RESOLUTION_PREFERENCE,
-    DEFAULT_RESOLUTION_PREFERENCE,
-    RESOLUTION_HIGH,
-    RESOLUTION_LOW,
-    EVENT_RECORDING_UPDATED,
-    CONF_UPLOAD_DELAY,
-    DEFAULT_UPLOAD_DELAY,
-    CONF_ENABLE_EVENT_DRIVEN,
-    DEFAULT_ENABLE_EVENT_DRIVEN,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -70,14 +66,14 @@ class ReolinkRecordingsCoordinator:
         
         # Persistent mapping between camera indices and names
         # This is the key to fixing the camera mixup issue
-        self.camera_index_map: Dict[int, str] = {}
+        self.camera_index_map: dict[int, str] = {}
         
         # Store NVR ID for each camera index
-        self.camera_nvr_map: Dict[int, str] = {}
+        self.camera_nvr_map: dict[int, str] = {}
         
         # Maps for snapshot paths
-        self.snapshot_paths: Dict[str, str] = {}  # GIF paths
-        self.jpg_snapshot_paths: Dict[str, str] = {}  # JPG paths
+        self.snapshot_paths: dict[str, str] = {}  # GIF paths
+        self.jpg_snapshot_paths: dict[str, str] = {}  # JPG paths
         
         # Get snapshot format preference or use default
         self.snapshot_format = DEFAULT_SNAPSHOT_FORMAT
@@ -224,7 +220,7 @@ class ReolinkRecordingsCoordinator:
             _LOGGER.error(f"Error refreshing Reolink recordings: {ex}")
             return False
 
-    def _merge_camera_data(self, cached_data: List[Dict[str, Any]], new_data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _merge_camera_data(self, cached_data: list[dict[str, Any]], new_data: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Merge new camera data with cached data, preserving valid cached entries if new one errors.
         
         Deduplicates by slug (lowercase, underscored) to prevent stale entries with
@@ -241,23 +237,13 @@ class ReolinkRecordingsCoordinator:
         # Index new data by slug, preferring proper-case names
         for c in new_data:
             slug = _slug(c.get("camera", ""))
-            if slug not in new_by_slug or (c.get("error") is None and "error" in new_by_slug[slug]):
-                new_by_slug[slug] = c
-            elif c.get("error") is None and new_by_slug[slug].get("error") is not None:
-                new_by_slug[slug] = c
-            # If both are valid, prefer proper-case name (contains space or mixed case)
-            elif c.get("error") is None and " " in c.get("camera", "") and " " not in new_by_slug[slug].get("camera", ""):
+            if slug not in new_by_slug or (c.get("error") is None and "error" in new_by_slug[slug]) or c.get("error") is None and new_by_slug[slug].get("error") is not None or c.get("error") is None and " " in c.get("camera", "") and " " not in new_by_slug[slug].get("camera", ""):
                 new_by_slug[slug] = c
         
         # Index cached data by slug, preferring proper-case names
         for c in cached_data:
             slug = _slug(c.get("camera", ""))
-            if slug not in cached_by_slug or (c.get("error") is None and "error" in cached_by_slug[slug]):
-                cached_by_slug[slug] = c
-            elif c.get("error") is None and cached_by_slug[slug].get("error") is not None:
-                cached_by_slug[slug] = c
-            # If both are valid, prefer proper-case name (contains space)
-            elif c.get("error") is None and " " in c.get("camera", "") and " " not in cached_by_slug[slug].get("camera", ""):
+            if slug not in cached_by_slug or (c.get("error") is None and "error" in cached_by_slug[slug]) or c.get("error") is None and cached_by_slug[slug].get("error") is not None or c.get("error") is None and " " in c.get("camera", "") and " " not in cached_by_slug[slug].get("camera", ""):
                 cached_by_slug[slug] = c
         
         # Get all unique slugs
@@ -304,7 +290,7 @@ class ReolinkRecordingsCoordinator:
         
         return list(merged_by_slug.values())
 
-    def _ensure_paths_for_camera(self, camera_data: Dict[str, Any]):
+    def _ensure_paths_for_camera(self, camera_data: dict[str, Any]):
         """Ensure recording_paths are populated for a camera data item."""
         camera_name = camera_data.get("camera")
         if not camera_name:
@@ -330,7 +316,7 @@ class ReolinkRecordingsCoordinator:
             if jpg_path.exists():
                 self.jpg_snapshot_paths[name] = str(jpg_path)
 
-    async def _scan_existing_files(self, cameras_data: List[Dict[str, Any]]):
+    async def _scan_existing_files(self, cameras_data: list[dict[str, Any]]):
         """Scan directory for existing files that might be missing from metadata."""
         # Get list of known cameras in current data
         known_cameras_lower = {c.get("camera", "").lower(): c for c in cameras_data}
@@ -375,7 +361,7 @@ class ReolinkRecordingsCoordinator:
         except Exception as e:
             _LOGGER.error(f"Error scanning existing files: {e}")
 
-    async def _discover_cameras(self) -> List[Dict[str, Any]]:
+    async def _discover_cameras(self) -> list[dict[str, Any]]:
         """Discover all Reolink cameras and their latest recordings."""
         # Get bearer token for API access
         token = await self._get_auth_token()
@@ -392,7 +378,7 @@ class ReolinkRecordingsCoordinator:
         results = []
         
         # Extract camera name to index mapping from media content IDs
-        _LOGGER.info(f"Discovering cameras and extracting reliable camera mappings")
+        _LOGGER.info("Discovering cameras and extracting reliable camera mappings")
         camera_name_to_index = {}
         
         for camera in root_result["children"]:
@@ -413,7 +399,7 @@ class ReolinkRecordingsCoordinator:
                 else:
                     _LOGGER.warning(f"Couldn't parse index from media_content_id: {camera['media_content_id']}")
             except (ValueError, IndexError) as e:
-                _LOGGER.warning(f"Error extracting camera index for {camera_name}: {str(e)}")
+                _LOGGER.warning(f"Error extracting camera index for {camera_name}: {e!s}")
         
         # Update our persistent camera mapping with the actual indices
         # Normalize camera names to proper title case for consistency
@@ -445,7 +431,7 @@ class ReolinkRecordingsCoordinator:
                 result = await self._get_latest_recording(camera_index, camera_name, token)
                 results.append(result)
             except Exception as e:
-                _LOGGER.error(f"Error processing camera {camera_name}: {str(e)}")
+                _LOGGER.error(f"Error processing camera {camera_name}: {e!s}")
                 results.append({
                     "camera": camera_name,
                     "error": str(e)
@@ -455,7 +441,7 @@ class ReolinkRecordingsCoordinator:
 
     async def _get_latest_recording(
         self, camera_index: int, camera_name: str, token: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Get the latest recording for a specific camera index."""
         # Step 1: Get camera resolution options
         # Get NVR ID from our camera mapping
@@ -599,7 +585,7 @@ class ReolinkRecordingsCoordinator:
             "recording_id": recording_id,  # Add unique identifier
         }
 
-    async def _download_recordings(self, cameras_data: List[Dict[str, Any]]):
+    async def _download_recordings(self, cameras_data: list[dict[str, Any]]):
         """Download recordings for each camera."""
         token = await self._get_auth_token()
         headers = {"Authorization": f"Bearer {token}"}
@@ -774,7 +760,7 @@ class ReolinkRecordingsCoordinator:
         # In a production environment, you'd use a more secure method
         return self.password
 
-    async def _browse_media(self, media_content_id: str, token: str) -> Dict[str, Any]:
+    async def _browse_media(self, media_content_id: str, token: str) -> dict[str, Any]:
         """Browse media using direct Media Source API calls.
         
         Args:
@@ -789,7 +775,7 @@ class ReolinkRecordingsCoordinator:
         
     # _browse_via_media_player method removed - always using direct Media Source API
     
-    async def _browse_via_websocket_api(self, media_content_id: str, token: str) -> Dict[str, Any]:
+    async def _browse_via_websocket_api(self, media_content_id: str, token: str) -> dict[str, Any]:
         """Browse media using direct WebSocket API calls to the media source."""
         _LOGGER.debug(f"Using direct Media Source API for {media_content_id}")
         
@@ -847,7 +833,7 @@ class ReolinkRecordingsCoordinator:
             return response_data.get("result", {})
             
         except Exception as e:
-            raise RuntimeError(f"WebSocket API error: {str(e)}")
+            raise RuntimeError(f"WebSocket API error: {e!s}")
         finally:
             if websocket:
                 await websocket.close()
@@ -903,7 +889,7 @@ class ReolinkRecordingsCoordinator:
 
     async def _generate_gif_snapshot(self, video_path: Path, snapshot_path: Path):
         """Generate an animated GIF from the video using ffmpeg."""
-        import subprocess, shlex
+        import shlex
 
         # Generate animated GIF with reduced settings to improve loading time:
         # - Scale to 320px width (reduced from 640px) for faster loading
@@ -921,7 +907,7 @@ class ReolinkRecordingsCoordinator:
         
         This is a much less CPU-intensive operation than generating an animated GIF.
         """
-        import subprocess, shlex
+        import shlex
         
         # Generate a single frame JPG snapshot from the beginning of the video
         # Using higher resolution (1024px width) and maximum quality (-q:v 1)
@@ -931,7 +917,7 @@ class ReolinkRecordingsCoordinator:
         if proc.returncode != 0:
             raise RuntimeError("ffmpeg failed to generate JPG snapshot")
 
-    async def _download_file(self, url: str, headers: Dict[str, str], dest_path: Path):
+    async def _download_file(self, url: str, headers: dict[str, str], dest_path: Path):
         """Download a file from a URL and save it to the destination path."""
         # Ensure the directory exists
         dest_path.parent.mkdir(parents=True, exist_ok=True)
@@ -970,7 +956,7 @@ class ReolinkRecordingsCoordinator:
             # Re-raise the CancelledError so the caller knows the operation was cancelled
             raise
         except Exception as e:
-            _LOGGER.error(f"Download failed: {str(e)}")
+            _LOGGER.error(f"Download failed: {e!s}")
             # Clean up partial file if it exists
             if os.path.exists(dest_path):
                 try:
@@ -1058,7 +1044,7 @@ class ReolinkRecordingsCoordinator:
             try:
                 # Use async file operations to avoid blocking warnings
                 import aiofiles
-                async with aiofiles.open(metadata_file, "r") as f:
+                async with aiofiles.open(metadata_file) as f:
                     content = await f.read()
                     metadata = json.loads(content)
                 
@@ -1087,7 +1073,7 @@ class ReolinkRecordingsCoordinator:
             except ImportError:
                 # Fallback to sync operations if aiofiles not available
                 try:
-                    with open(metadata_file, "r") as f:
+                    with open(metadata_file) as f:
                         metadata = json.load(f)
                     
                     if "data" in metadata:

--- a/coordinator.py
+++ b/coordinator.py
@@ -45,8 +45,7 @@ class ReolinkRecordingsCoordinator:
         hass: HomeAssistant,
         entry_id: str,
         host: str,
-        username: str,
-        password: str,
+        access_token: str,
         storage_dir: Path,
         entry: ConfigEntry = None,  # Added to support snapshot format options
     ):
@@ -54,8 +53,7 @@ class ReolinkRecordingsCoordinator:
         self.hass = hass
         self.entry_id = entry_id
         self.host = host
-        self.username = username
-        self.password = password
+        self.access_token = access_token
         self.storage_dir = storage_dir
         self.entry = entry  # Store config entry for options access
         self.session = async_get_clientsession(hass)
@@ -755,10 +753,8 @@ class ReolinkRecordingsCoordinator:
                 _LOGGER.error(f"Error downloading recording for {camera_name}: {e}")
 
     async def _get_auth_token(self) -> str:
-        """Get authentication token from Home Assistant."""
-        # For now, we'll assume the long-lived access token is stored in the password field
-        # In a production environment, you'd use a more secure method
-        return self.password
+        """Return the configured long-lived access token."""
+        return self.access_token
 
     async def _browse_media(self, media_content_id: str, token: str) -> dict[str, Any]:
         """Browse media using direct Media Source API calls.
@@ -891,17 +887,36 @@ class ReolinkRecordingsCoordinator:
     async def _generate_gif_snapshot(self, video_path: Path, snapshot_path: Path):
         """Generate an animated GIF from the video using ffmpeg."""
         import shlex
+        import tempfile
 
         # Generate animated GIF with reduced settings to improve loading time:
         # - Scale to 320px width (reduced from 640px) for faster loading
         # - Reduced to 1fps (from 2fps) to make files smaller
         # - Still using palette optimization for quality
         # - Limit to first 5 seconds (reduced from 10 seconds) for smaller file size
-        cmd = f"ffmpeg -y -t 5 -i {shlex.quote(str(video_path))} -vf \"fps=1,scale=320:-1:flags=lanczos,palettegen=max_colors=128:stats_mode=diff\" -f image2 /tmp/palette.png && ffmpeg -y -t 5 -i {shlex.quote(str(video_path))} -i /tmp/palette.png -filter_complex \"fps=1,scale=320:-1:flags=lanczos[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=5\" {shlex.quote(str(snapshot_path))}"
-        proc = await asyncio.create_subprocess_shell(cmd, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL)
-        await proc.communicate()
-        if proc.returncode != 0:
-            raise RuntimeError("ffmpeg failed to generate animated GIF")
+        # Use a unique temp palette per invocation to avoid collisions when
+        # multiple cameras generate GIFs concurrently.
+        with tempfile.TemporaryDirectory(prefix="reolink_gif_") as tmpdir:
+            palette_path = Path(tmpdir) / "palette.png"
+            video = shlex.quote(str(video_path))
+            palette = shlex.quote(str(palette_path))
+            snapshot = shlex.quote(str(snapshot_path))
+            cmd = (
+                f"ffmpeg -y -t 5 -i {video} "
+                f'-vf "fps=1,scale=320:-1:flags=lanczos,palettegen=max_colors=128:stats_mode=diff" '
+                f"-f image2 {palette} && "
+                f"ffmpeg -y -t 5 -i {video} -i {palette} "
+                f'-filter_complex "fps=1,scale=320:-1:flags=lanczos[x];'
+                f'[x][1:v]paletteuse=dither=bayer:bayer_scale=5" {snapshot}'
+            )
+            proc = await asyncio.create_subprocess_shell(
+                cmd,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await proc.communicate()
+            if proc.returncode != 0:
+                raise RuntimeError("ffmpeg failed to generate animated GIF")
     
     async def _generate_jpg_snapshot(self, video_path: Path, snapshot_path: Path):
         """Generate a single JPG snapshot from the video using ffmpeg.

--- a/coordinator.py
+++ b/coordinator.py
@@ -791,7 +791,8 @@ class ReolinkRecordingsCoordinator:
                 websocket_url = f"ws://{self.host}/api/websocket"
                 
             _LOGGER.debug(f"Connecting to WebSocket at {websocket_url}")
-            websocket = await websockets.connect(websocket_url, ssl=None)
+            # Use library defaults: verified TLS for wss://, no SSL for ws://
+            websocket = await websockets.connect(websocket_url)
             
             # WebSocket handshake - receive initial auth required message
             auth_required = await websocket.recv()

--- a/device_trigger.py
+++ b/device_trigger.py
@@ -1,14 +1,15 @@
 """Device trigger support for Reolink Recordings."""
 from __future__ import annotations
 
-import voluptuous as vol
 from typing import Any
+
+import voluptuous as vol
 
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.homeassistant.triggers import event as event_trigger
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
@@ -151,7 +152,7 @@ def _create_filtered_action(action: TriggerActionType, camera_name: str, trigger
         
         # Skip if no camera data (incomplete event)
         if not event_camera:
-            _LOGGER.debug(f"Skipping event with no camera data")
+            _LOGGER.debug("Skipping event with no camera data")
             return
         
         # Check if this event is for our camera (normalize names for comparison)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,23 @@
+import js from "@eslint/js";
+import globals from "globals";
+
+export default [
+  {
+    ignores: ["node_modules/"],
+  },
+  js.configs.recommended,
+  {
+    files: ["frontend/**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "script",
+      globals: {
+        ...globals.browser,
+        customElements: "readonly",
+      },
+    },
+    rules: {
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    },
+  },
+];

--- a/frontend.py
+++ b/frontend.py
@@ -1,12 +1,10 @@
 """Frontend code for Reolink Recordings component."""
 from __future__ import annotations
 
-import os
-import logging
-import shutil
-import asyncio
 import concurrent.futures
+import logging
 from pathlib import Path
+import shutil
 
 from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.core import HomeAssistant

--- a/frontend/reolink-recording-card.js
+++ b/frontend/reolink-recording-card.js
@@ -1,7 +1,8 @@
 /**
  * Reolink Recording Card for Home Assistant
- * v1.1.2
- * A simple card to display Reolink camera recordings with auto-refresh
+ * v1.2.0
+ * A simple card to display Reolink camera recordings with auto-refresh.
+ * Recording media URLs are served via authenticated /media-source/ paths.
  */
 class ReolinkRecordingCard extends HTMLElement {
   static getConfigElement() {
@@ -928,7 +929,7 @@ class ReolinkRecordingCardEditor extends HTMLElement {
 }
 
 // Defensive registration pattern for reliability on slower devices
-const CARD_VERSION = '1.1.0';
+const CARD_VERSION = '1.2.0';
 const CARD_NAME = 'Reolink Recording Card';
 
 function registerReolinkCard() {

--- a/frontend/reolink-recording-card.js
+++ b/frontend/reolink-recording-card.js
@@ -369,7 +369,6 @@ class ReolinkRecordingCard extends HTMLElement {
       if (videoUrl) {
         const card = this.shadowRoot?.querySelector('.image-container');
         if (card) {
-          const oldHandler = card.onclick;
           card.onclick = () => this.handleTap(videoUrl);
         }
       }
@@ -563,7 +562,7 @@ class ReolinkRecordingCard extends HTMLElement {
         } else {
           cacheBuster = `t=${now}-${Math.floor(Math.random() * 1000)}`;
         }
-      } catch (e) {
+      } catch {
         // If parsing fails, generate a new timestamp
         cacheBuster = `t=${Date.now()}-${Math.floor(Math.random() * 1000)}`;
       }

--- a/frontend/reolink-summary-card.js
+++ b/frontend/reolink-summary-card.js
@@ -124,7 +124,9 @@ class ReolinkSummaryCard extends HTMLElement {
           return new Date(y, mo, d, h, mi, s);
         }
       }
-    } catch(e) {}
+    } catch {
+      // Ignore parse failures and use fallback below
+    }
     return new Date(0); // fallback
   }
 

--- a/frontend/reolink-summary-card.js
+++ b/frontend/reolink-summary-card.js
@@ -1,7 +1,9 @@
 /**
  * Reolink Summary Card for Home Assistant
+ * v1.1.0
  * A custom card that pulls together all Reolink recordings,
  * sorts them by recency, and displays them dynamically.
+ * Recording media URLs are served via authenticated /media-source/ paths.
  */
 class ReolinkSummaryCard extends HTMLElement {
   static getConfigElement() {
@@ -144,8 +146,8 @@ class ReolinkSummaryCard extends HTMLElement {
       if (!stateObj) return;
 
       const attrs = stateObj.attributes;
-      // Skip if missing critical info
-      if (!attrs || !attrs.file_path) return;
+      // Skip if missing critical info (file_name indicates a recording is available)
+      if (!attrs || (!attrs.file_name && !attrs.media_url)) return;
 
       const recDate = this._parseRecordingDate(attrs.date, attrs.timestamp);
       

--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,58 @@
+"""Shared helpers for the Reolink Recordings integration."""
+from pathlib import Path
+
+from homeassistant.core import HomeAssistant
+
+
+def resolve_storage_path(hass: HomeAssistant, storage_path: str) -> Path:
+    """Resolve storage_path to an absolute Path.
+
+    Absolute paths are used as-is. Relative paths are resolved under the
+    Home Assistant config directory.
+    """
+    path = Path(storage_path.strip())
+    if path.is_absolute():
+        return path
+    return Path(hass.config.path(storage_path))
+
+
+def is_www_storage_path(hass: HomeAssistant, storage_path: str) -> bool:
+    """Return True if storage_path is under the publicly served www/ tree."""
+    normalized = str(storage_path).replace("\\", "/").strip().lstrip("./")
+    if normalized == "www" or normalized.startswith("www/"):
+        return True
+
+    try:
+        resolved = resolve_storage_path(hass, storage_path).resolve()
+        www_root = Path(hass.config.path("www")).resolve()
+        resolved.relative_to(www_root)
+        return True
+    except (ValueError, OSError):
+        return False
+
+
+def validate_storage_path(hass: HomeAssistant, storage_path: str) -> str | None:
+    """Validate storage_path; return an error key or None if valid.
+
+    Absolute paths are allowed (e.g. /media or a NAS mount). Relative paths
+    must stay under the Home Assistant config directory (no ``..`` escape).
+    Paths under www/ are allowed but insecure — callers should warn the user.
+    """
+    if not storage_path or not str(storage_path).strip():
+        return "invalid_storage_path"
+
+    path = Path(storage_path.strip())
+    if ".." in path.parts:
+        return "invalid_storage_path"
+
+    if path.is_absolute():
+        return None
+
+    # Relative path: must resolve under config root (blocks .. and similar).
+    config_root = Path(hass.config.path()).resolve()
+    try:
+        resolve_storage_path(hass, storage_path).resolve().relative_to(config_root)
+    except (ValueError, OSError):
+        return "invalid_storage_path"
+
+    return None

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,6 @@
   ],
   "config_flow": true,
   "iot_class": "local_polling",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "requirements": []
 }

--- a/media_source.py
+++ b/media_source.py
@@ -2,14 +2,13 @@
 import logging
 import mimetypes
 import os
-from typing import Tuple
 
 from homeassistant.components.media_player.const import MediaClass, MediaType
+
 # Backwards compatibility for code still using old constant names
 MEDIA_CLASS_DIRECTORY = getattr(MediaClass, "DIRECTORY", "directory")
 MEDIA_CLASS_VIDEO = getattr(MediaClass, "VIDEO", "video")
 MEDIA_TYPE_VIDEO = getattr(MediaType, "VIDEO", "video")
-from homeassistant.components.media_source.const import MEDIA_MIME_TYPES
 from homeassistant.components.media_source.error import MediaSourceError, Unresolvable
 from homeassistant.components.media_source.models import (
     BrowseMediaSource,
@@ -19,16 +18,18 @@ from homeassistant.components.media_source.models import (
 
 # MediaSourceResponse was introduced in HA 2025.4; fall back if older core
 try:
-    from homeassistant.components.media_source.models import MediaSourceResponse  # type: ignore
+    from homeassistant.components.media_source.models import (
+        MediaSourceResponse,  # type: ignore
+    )
 except ImportError:  # pragma: no cover
     class MediaSourceResponse:  # minimal shim
         """Fallback response object for older Home Assistant versions."""
         def __init__(self, url: str, mime_type: str | None = None):
             self.url = url
             self.mime_type = mime_type or ""
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, DATA_COORDINATOR
+from .const import DATA_COORDINATOR, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,10 +60,10 @@ class ReolinkRecordingsMediaSource(MediaSource):
 
         _LOGGER.debug("Resolving media identifier %s", item.identifier)
         # Find the file
-        for entry_id, entry_data in self.hass.data[DOMAIN].items():
+        for _entry_id, entry_data in self.hass.data[DOMAIN].items():
             coordinator = entry_data[DATA_COORDINATOR]
             # Videos
-            for camera_name, recording_path in coordinator.recording_paths.items():
+            for _camera_name, recording_path in coordinator.recording_paths.items():
                 if os.path.basename(recording_path) == item.identifier:
                     mime_type, _ = mimetypes.guess_type(recording_path)
                     # Return the actual file path for Home Assistant to serve
@@ -72,7 +73,7 @@ class ReolinkRecordingsMediaSource(MediaSource):
                     
             # Snapshots (GIF)
             if hasattr(coordinator, "snapshot_paths"):
-                for camera_name, snapshot_path in coordinator.snapshot_paths.items():
+                for _camera_name, snapshot_path in coordinator.snapshot_paths.items():
                     if os.path.basename(snapshot_path) == item.identifier:
                         mime_type, _ = mimetypes.guess_type(snapshot_path)
                         # Return the actual file path for Home Assistant to serve
@@ -81,7 +82,7 @@ class ReolinkRecordingsMediaSource(MediaSource):
 
             # Snapshots (JPG)
             if hasattr(coordinator, "jpg_snapshot_paths"):
-                for camera_name, snapshot_path in coordinator.jpg_snapshot_paths.items():
+                for _camera_name, snapshot_path in coordinator.jpg_snapshot_paths.items():
                     if os.path.basename(snapshot_path) == item.identifier:
                         mime_type, _ = mimetypes.guess_type(snapshot_path)
                         _LOGGER.debug(f"Resolving {item.identifier} to {snapshot_path}")
@@ -114,7 +115,7 @@ class ReolinkRecordingsMediaSource(MediaSource):
         """Browse cameras."""
         cameras = {}
 
-        for entry_id, entry_data in self.hass.data[DOMAIN].items():
+        for _entry_id, entry_data in self.hass.data[DOMAIN].items():
             coordinator = entry_data[DATA_COORDINATOR]
             for camera_name, recording_path in coordinator.recording_paths.items():
                 cameras[camera_name] = recording_path

--- a/media_source.py
+++ b/media_source.py
@@ -70,12 +70,20 @@ class ReolinkRecordingsMediaSource(MediaSource):
                     _LOGGER.debug(f"Resolving {item.identifier} to {recording_path}")
                     return MediaSourceResponse(recording_path, mime_type or "")
                     
-            # Snapshots
+            # Snapshots (GIF)
             if hasattr(coordinator, "snapshot_paths"):
                 for camera_name, snapshot_path in coordinator.snapshot_paths.items():
                     if os.path.basename(snapshot_path) == item.identifier:
                         mime_type, _ = mimetypes.guess_type(snapshot_path)
                         # Return the actual file path for Home Assistant to serve
+                        _LOGGER.debug(f"Resolving {item.identifier} to {snapshot_path}")
+                        return MediaSourceResponse(snapshot_path, mime_type or "")
+
+            # Snapshots (JPG)
+            if hasattr(coordinator, "jpg_snapshot_paths"):
+                for camera_name, snapshot_path in coordinator.jpg_snapshot_paths.items():
+                    if os.path.basename(snapshot_path) == item.identifier:
+                        mime_type, _ = mimetypes.guess_type(snapshot_path)
                         _LOGGER.debug(f"Resolving {item.identifier} to {snapshot_path}")
                         return MediaSourceResponse(snapshot_path, mime_type or "")
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1112 @@
+{
+  "name": "reolink-recordings",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "reolink-recordings",
+      "devDependencies": {
+        "@eslint/js": "^9.39.1",
+        "eslint": "^9.39.1",
+        "globals": "^16.5.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "reolink-recordings",
+  "private": true,
+  "type": "module",
+  "description": "Dev tooling for Reolink Recordings Home Assistant integration",
+  "scripts": {
+    "lint": "eslint frontend/"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.1",
+    "eslint": "^9.39.1",
+    "globals": "^16.5.0"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+extend-exclude = [".venv"]
+
+[tool.ruff.lint]
+select = [
+    "E",
+    "F",
+    "I",
+    "UP",
+    "B",
+    "SIM",
+]
+ignore = [
+    "BLE001",   # broad except handlers are common in HA integrations
+    "DTZ",      # timezone-aware datetime refactors tracked separately
+    "ASYNC230", # blocking file I/O inside async download paths
+    "PERF102",  # dict .items() vs .values() micro-optimizations
+    "E501",     # line length; existing code uses longer log strings
+    "E402",     # media_source.py uses conditional imports for HA compat
+    "SIM108",   # ternary readability preference in coordinator
+    "B904",     # raise-without-from in legacy error paths
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["homeassistant"]
+force-sort-within-sections = true
+combine-as-imports = true

--- a/sensor.py
+++ b/sensor.py
@@ -99,6 +99,10 @@ class ReolinkRecordingSensor(CoordinatorEntity, SensorEntity):
         self._snapshot_format = coordinator.entry.options.get(
             CONF_SNAPSHOT_FORMAT, DEFAULT_SNAPSHOT_FORMAT
         )
+
+    def _media_source_url(self, filename: str, timestamp: str) -> str:
+        """Return an authenticated media-source URL for a recording asset."""
+        return f"/media-source/{DOMAIN}/{filename}?t={timestamp}"
     
     def _find_camera_data(self) -> Optional[Dict[str, Any]]:
         """Find the best matching camera data for this sensor.
@@ -240,8 +244,10 @@ class ReolinkRecordingSensor(CoordinatorEntity, SensorEntity):
                 attributes["file_path"] = recording_path
                 attributes["file_name"] = self._video_filename
                 
-                # Media URL (MP4) for tap-to-play - using /local/ URL via symlink
-                attributes["media_url"] = f"/local/reolink_recordings/recordings/{self._video_filename}?t={timestamp}"
+                # Media URL (MP4) for tap-to-play via authenticated media source
+                attributes["media_url"] = self._media_source_url(
+                    self._video_filename, timestamp
+                )
 
                 # Select the appropriate snapshot image based on configuration
                 # Lookup paths with case-insensitive fallback
@@ -262,33 +268,44 @@ class ReolinkRecordingSensor(CoordinatorEntity, SensorEntity):
                 # Choose which snapshot to use for entity_picture
                 if self._snapshot_format == SNAPSHOT_FORMAT_GIF and gif_path:
                     # Use GIF if configured for GIF only
-                    picture_url = f"/local/reolink_recordings/recordings/{self._gif_snapshot_filename}?t={timestamp}"
+                    picture_url = self._media_source_url(
+                        self._gif_snapshot_filename, timestamp
+                    )
                     attributes["entity_picture"] = picture_url
                     self._attr_entity_picture = picture_url
                 elif self._snapshot_format == SNAPSHOT_FORMAT_JPG and jpg_path:
                     # Use JPG if configured for JPG only
-                    picture_url = f"/local/reolink_recordings/recordings/{self._jpg_snapshot_filename}?t={timestamp}"
+                    picture_url = self._media_source_url(
+                        self._jpg_snapshot_filename, timestamp
+                    )
                     attributes["entity_picture"] = picture_url
                     self._attr_entity_picture = picture_url
                 elif self._snapshot_format == SNAPSHOT_FORMAT_BOTH:
                     # If both, prefer GIF for entity_picture but include JPG as alternate_picture
                     if gif_path:
-                        gif_url = f"/local/reolink_recordings/recordings/{self._gif_snapshot_filename}?t={timestamp}"
+                        gif_url = self._media_source_url(
+                            self._gif_snapshot_filename, timestamp
+                        )
                         attributes["entity_picture"] = gif_url
                         self._attr_entity_picture = gif_url
                         
                         # If we also have a JPG, add it as an alternate
                         if jpg_path:
-                            jpg_url = f"/local/reolink_recordings/recordings/{self._jpg_snapshot_filename}?t={timestamp}"
-                            attributes["jpg_picture"] = jpg_url
+                            attributes["jpg_picture"] = self._media_source_url(
+                                self._jpg_snapshot_filename, timestamp
+                            )
                     elif jpg_path:
                         # Fall back to JPG if GIF not available but we wanted both
-                        jpg_url = f"/local/reolink_recordings/recordings/{self._jpg_snapshot_filename}?t={timestamp}"
+                        jpg_url = self._media_source_url(
+                            self._jpg_snapshot_filename, timestamp
+                        )
                         attributes["entity_picture"] = jpg_url
                         self._attr_entity_picture = jpg_url
                 else:
                     # Fallback to using the mp4 (may not render in picture card)
-                    picture_url = f"/media-source/{DOMAIN}/{self._video_filename}?t={timestamp}"
+                    picture_url = self._media_source_url(
+                        self._video_filename, timestamp
+                    )
                     attributes["entity_picture"] = picture_url
                     self._attr_entity_picture = picture_url
                 

--- a/sensor.py
+++ b/sensor.py
@@ -1,8 +1,8 @@
 """Sensor platform for Reolink Recordings."""
-import os
+from datetime import UTC, datetime, timedelta
 import logging
-from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional
+import os
+from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -10,20 +10,20 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt as dt_util
+
 try:
     from zoneinfo import ZoneInfo
 except ImportError:
     from backports.zoneinfo import ZoneInfo
 
 from .const import (
-    DOMAIN,
-    DATA_COORDINATOR,
     CONF_SNAPSHOT_FORMAT,
+    DATA_COORDINATOR,
+    DEFAULT_SNAPSHOT_FORMAT,
+    DOMAIN,
+    SNAPSHOT_FORMAT_BOTH,
     SNAPSHOT_FORMAT_GIF,
     SNAPSHOT_FORMAT_JPG,
-    SNAPSHOT_FORMAT_BOTH,
-    DEFAULT_SNAPSHOT_FORMAT,
 )
 from .coordinator import ReolinkRecordingsCoordinator
 
@@ -104,7 +104,7 @@ class ReolinkRecordingSensor(CoordinatorEntity, SensorEntity):
         """Return an authenticated media-source URL for a recording asset."""
         return f"/media-source/{DOMAIN}/{filename}?t={timestamp}"
     
-    def _find_camera_data(self) -> Optional[Dict[str, Any]]:
+    def _find_camera_data(self) -> dict[str, Any] | None:
         """Find the best matching camera data for this sensor.
         
         When multiple entries match by slug (e.g., 'first_landing' and 'First Landing'),
@@ -113,10 +113,9 @@ class ReolinkRecordingSensor(CoordinatorEntity, SensorEntity):
         matches = []
         for camera_data in self.coordinator.data.get("cameras", []):
             camera_name = camera_data.get("camera", "")
-            if camera_name == self.camera_name or \
-               camera_name.lower() == self.camera_name.lower():
-                if "error" not in camera_data:
-                    matches.append(camera_data)
+            if (camera_name == self.camera_name or \
+               camera_name.lower() == self.camera_name.lower()) and "error" not in camera_data:
+                matches.append(camera_data)
         
         if not matches:
             return None
@@ -149,7 +148,7 @@ class ReolinkRecordingSensor(CoordinatorEntity, SensorEntity):
         # Case-insensitive fallback
         return any(k.lower() == self.camera_name.lower() for k in self.coordinator.recording_paths)
     
-    def _get_corrected_timestamp(self, camera_data: Dict[str, Any]) -> tuple:
+    def _get_corrected_timestamp(self, camera_data: dict[str, Any]) -> tuple:
         """Return (date, timestamp) using file mtime if the API timestamp is stale.
         
         The Reolink NVR API can lag behind the actual recording file on disk.
@@ -182,7 +181,7 @@ class ReolinkRecordingSensor(CoordinatorEntity, SensorEntity):
                     tz_str = "UTC"
                 tz = ZoneInfo(tz_str)
                 file_mtime = datetime.fromtimestamp(
-                    os.path.getmtime(recording_path), tz=timezone.utc
+                    os.path.getmtime(recording_path), tz=UTC
                 ).astimezone(tz)
                 date_parts = api_date.split("/")
                 time_parts = api_timestamp.split(":")
@@ -204,7 +203,7 @@ class ReolinkRecordingSensor(CoordinatorEntity, SensorEntity):
         return (api_date, api_timestamp)
     
     @property
-    def state(self) -> Optional[str]:
+    def state(self) -> str | None:
         """Return the state of the sensor."""
         camera_data = self._find_camera_data()
         if camera_data is None:
@@ -215,7 +214,7 @@ class ReolinkRecordingSensor(CoordinatorEntity, SensorEntity):
         return f"{date} {timestamp} - {event_type}"
     
     @property
-    def extra_state_attributes(self) -> Dict[str, Any]:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return entity specific state attributes."""
         attributes = {}
         now = datetime.now()

--- a/services.yaml
+++ b/services.yaml
@@ -1,22 +1,8 @@
-fetch_latest_recordings:
-  name: Fetch Latest Recordings
-  description: Fetches the latest recordings from all Reolink cameras and downloads them.
-  
-download_recording:
-  name: Download Recording
-  description: Downloads a specific recording from a Reolink camera.
+refresh:
   fields:
-    camera_name:
-      name: Camera Name
-      description: Name of the camera to download from.
-      required: true
-      example: "Front door"
-      selector:
-        text:
-    entity_id:
-      name: Entity ID
-      description: Entity ID of the integration.
+    entry_id:
+      example: "0123456789abcdef0123456789abcdef"
       required: false
       selector:
-        entity:
+        config_entry:
           integration: reolink_recordings

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,4 +1,16 @@
 {
+  "services": {
+    "refresh": {
+      "name": "Refresh recordings",
+      "description": "Fetches and downloads the latest recordings from the Reolink Home Hub.",
+      "fields": {
+        "entry_id": {
+          "name": "Config entry",
+          "description": "Config entry to refresh. Defaults to the entry that registered the service."
+        }
+      }
+    }
+  },
   "device_automation": {
     "trigger_type": {
       "recording_updated": "New recording available",

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,12 +1,51 @@
 {
+  "config": {
+    "step": {
+      "user": {
+        "title": "Reolink Recordings",
+        "description": "Connect using a Home Assistant long-lived access token.",
+        "data": {
+          "name": "Name",
+          "host": "Home Assistant URL",
+          "access_token": "Long-lived access token"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Unable to connect or validate configuration"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Reolink Recordings options",
+        "data": {
+          "scan_interval": "Scan interval (minutes)",
+          "storage_path": "Storage path (relative to config, or absolute e.g. /media/...; avoid www/)",
+          "snapshot_format": "Snapshot format",
+          "enable_caching": "Enable caching",
+          "resolution_preference": "Resolution preference",
+          "enable_event_driven": "Enable event-driven discovery",
+          "upload_delay": "Upload delay after motion (seconds)"
+        }
+      },
+      "motion_sensors": {
+        "title": "Motion sensor mapping",
+        "description": "{info}"
+      }
+    },
+    "error": {
+      "invalid_storage_path": "Storage path must be a non-empty absolute path, or a relative path under the Home Assistant config directory (no ..)."
+    }
+  },
   "services": {
     "refresh": {
       "name": "Refresh recordings",
-      "description": "Fetches and downloads the latest recordings from the Reolink Home Hub.",
+      "description": "Fetches and downloads the latest recordings from the Reolink Home Hub. Requires an admin user.",
       "fields": {
         "entry_id": {
           "name": "Config entry",
-          "description": "Config entry to refresh. Defaults to the entry that registered the service."
+          "description": "Config entry to refresh. Defaults to all loaded entries when omitted."
         }
       }
     }
@@ -15,7 +54,7 @@
     "trigger_type": {
       "recording_updated": "New recording available",
       "vehicle_detected": "Vehicle detected in recording",
-      "person_detected": "Person detected in recording", 
+      "person_detected": "Person detected in recording",
       "motion_detected": "Motion detected in recording"
     }
   }


### PR DESCRIPTION
#### Summary
- Store the long-lived HA token in a dedicated access_token config key instead of CONF_PASSWORD; drop unused CONF_USERNAME
- Add config entry migration (v2→v3) in __init__.py: move legacy password → access_token, migrate www/reolink_recordings storage path, bump config flow to VERSION = 3
- Restrict reolink_recordings.refresh to admin users via async_register_admin_service (automations still work; non-admin manual calls are blocked)
- Register the refresh service once per HA instance; refresh all loaded entries when entry_id is omitted; remove the service on last unload
- Add helpers.py for storage path handling: allow absolute paths (e.g. /media, NAS mounts); require relative paths stay under config and reject ..; warn (don’t block) on www/ paths
- Validate storage_path in options flow and at setup; fail setup with ConfigEntryError on invalid paths
- Fix concurrent GIF generation by using a per-run tempfile.TemporaryDirectory instead of shared /tmp/palette.png
- Update config flow UI, translations/en.json, and README for the new token field and storage path behavior